### PR TITLE
WIP: Implement Relations Mutation and fix performance

### DIFF
--- a/src/tidbit/collections/collection.ts
+++ b/src/tidbit/collections/collection.ts
@@ -42,7 +42,7 @@ export type CollectionMetadata = {
 export type MutateFunction = (sourceFieldValue: any) => any;
 
 export type RelationOptions = {
-  collection: CollectionMetadata;
+  collection: Omit<CollectionMetadata, "loadInMemory">;
   sourceField: string;
   foreignField: string;
   mutateSourceValue?: MutateFunction;

--- a/src/tidbit/collections/collection.ts
+++ b/src/tidbit/collections/collection.ts
@@ -39,10 +39,13 @@ export type CollectionMetadata = {
   loadInMemory: boolean;
 };
 
+export type MutateFunction = (sourceFieldValue: any) => any;
+
 export type RelationOptions = {
   collection: CollectionMetadata;
   sourceField: string;
   foreignField: string;
+  mutateSourceValue?: MutateFunction;
 };
 export interface Collection {
   /**

--- a/src/tidbit/collections/memory/CollectionInMemory.ts
+++ b/src/tidbit/collections/memory/CollectionInMemory.ts
@@ -76,8 +76,8 @@ export class CollectionInMemory extends Collection {
           if (this.searchOptions.relationOptions) {
             const colMeta = this.searchOptions.relationOptions.collection;
             const relationCollection = CollectionFactory(
-              colMeta,
-              colMeta.loadInMemory
+              { ...colMeta, loadInMemory: true },
+              true // Currently the relations metadata only supports in memory loading
             );
             const relationResult = await queryRelations(
               relationCollection,

--- a/src/tidbit/collections/memory/CollectionInMemory.ts
+++ b/src/tidbit/collections/memory/CollectionInMemory.ts
@@ -74,7 +74,13 @@ export class CollectionInMemory extends Collection {
       results = await Promise.all(
         results.map(async (result: any) => {
           if (this.searchOptions.relationOptions) {
+            const colMeta = this.searchOptions.relationOptions.collection;
+            const relationCollection = CollectionFactory(
+              colMeta,
+              colMeta.loadInMemory
+            );
             const relationResult = await queryRelations(
+              relationCollection,
               result[this.searchOptions.relationOptions.sourceField],
               this.searchOptions.relationOptions
             );

--- a/src/tidbit/collections/stream/ProjectStream.ts
+++ b/src/tidbit/collections/stream/ProjectStream.ts
@@ -25,8 +25,8 @@ export class ProjectStream extends Transform {
       if (this.relationOptions) {
         const colMeta = this.relationOptions.collection;
         const relationCollection = CollectionFactory(
-          colMeta,
-          colMeta.loadInMemory
+          { ...colMeta, loadInMemory: true },
+          true // Currently the relations metadata only supports in memory loading
         );
         const relationResult = await queryRelations(
           relationCollection,

--- a/src/tidbit/collections/stream/ProjectStream.ts
+++ b/src/tidbit/collections/stream/ProjectStream.ts
@@ -2,6 +2,7 @@ import { Transform } from "node:stream";
 import { queryRelations } from "../../find/queryRelations";
 import { RelationOptions } from "../collection";
 import { TransformCallback } from "stream";
+import { CollectionFactory } from "../utils/CollectionFactory";
 export type ProjectFunction = (result: object, relation?: object) => object;
 
 export class ProjectStream extends Transform {
@@ -22,7 +23,13 @@ export class ProjectStream extends Transform {
     let result;
     if (typeof this.projectFunction === "function") {
       if (this.relationOptions) {
+        const colMeta = this.relationOptions.collection;
+        const relationCollection = CollectionFactory(
+          colMeta,
+          colMeta.loadInMemory
+        );
         const relationResult = await queryRelations(
+          relationCollection,
           json[this.relationOptions.sourceField],
           this.relationOptions
         );

--- a/src/tidbit/find/queryRelations.ts
+++ b/src/tidbit/find/queryRelations.ts
@@ -1,5 +1,4 @@
 import { Collection, RelationOptions } from "../collections/collection";
-import { CollectionFactory } from "../collections/utils/CollectionFactory";
 
 export async function queryRelations(
   relationCollection: Collection,

--- a/src/tidbit/find/queryRelations.ts
+++ b/src/tidbit/find/queryRelations.ts
@@ -1,17 +1,20 @@
-import { RelationOptions } from "../collections/collection";
+import { Collection, RelationOptions } from "../collections/collection";
 import { CollectionFactory } from "../collections/utils/CollectionFactory";
 
 export async function queryRelations(
+  relationCollection: Collection,
   sourceValue: any,
   relationOptions?: RelationOptions
 ): Promise<object> {
   let result: object[] = [];
   if (relationOptions) {
-    const colMeta = relationOptions.collection;
-    const relationCollection = CollectionFactory(colMeta, colMeta.loadInMemory);
+    let value = sourceValue;
+    if (relationOptions.mutateSourceValue) {
+      value = relationOptions.mutateSourceValue(value);
+    }
     result = await relationCollection
       .find({
-        [relationOptions.foreignField]: sourceValue, //FIX:  it
+        [relationOptions.foreignField]: value,
       })
       .toArray();
   }

--- a/tests/memory.spec.ts
+++ b/tests/memory.spec.ts
@@ -107,6 +107,24 @@ describe("TidBit Memory", () => {
     expect(results).toStrictEqual(expected);
   });
 
+  it("should be able to filter by name 'john' and surname 'doe' in different ways", async () => {
+    //Arrange
+    const query = { name: "john", surname: "doe" };
+    const queryWithAnds = { AND: [{ name: "john" }, { surname: "doe" }] };
+    //Act
+    const resultsWithoutANDS = await tidbit
+      .collection("simple")
+      .find(query)
+      .toArray();
+    const resultsWithANDS = await tidbit
+      .collection("simple")
+      .find(queryWithAnds)
+      .toArray();
+
+    //Assert
+    expect(resultsWithoutANDS).toStrictEqual(resultsWithANDS);
+  });
+
   it("should not be able to filter by name 'rufus'", async () => {
     //Arrange
     const query = { name: "rufus" };

--- a/tests/stream.spec.ts
+++ b/tests/stream.spec.ts
@@ -336,7 +336,6 @@ describe("TidBit Streams - toArray", () => {
       .find(query)
       .toArray();
 
-    console.log(results);
     //Assert
     expect(results).toStrictEqual(expected);
   });


### PR DESCRIPTION
This PR is one of the planned PR's to improve the functionality of co-relations with other collections to form a new dataset.

We improved the collection creation when there is relation to be executed, in order to reuse it instead of recreating a new one all the time

We also implemented a new property to be passed to the relations metadata, to mutate the source key's value. This is useful when the value from both datasets are equal, but with small differences(prefix, lowercase,etc...)